### PR TITLE
feat/내 동아리 페이지 버튼 추가, 동아리 상세 페이지 수정

### DIFF
--- a/assets/club-detail.html
+++ b/assets/club-detail.html
@@ -34,7 +34,7 @@
                 <button class="applyingBtn" onclick="openApplyingModal()">
                     동아리 신청하기
                 </button>
-                <button>동아리 대결 신청하기</button>
+                <button class="applyingClubMatch">동아리 대결 신청하기</button>
 
                 <!-- 내 동아리 들어가면 동아리 삭제 버튼 띄우기 -->
                 <button class="deleteBtn" onclick="deleteCheck()">

--- a/assets/css/club-detail.css
+++ b/assets/css/club-detail.css
@@ -52,3 +52,11 @@
 .applyingClubMatch {
     display: none;
 }
+
+.myClubApplication {
+    display: none;
+}
+
+.matchManagement {
+    display: none;
+}

--- a/assets/css/club-detail.css
+++ b/assets/css/club-detail.css
@@ -48,3 +48,7 @@
 .applyingBtn {
     display: none;
 }
+
+.applyingClubMatch {
+    display: none;
+}

--- a/assets/js/club-detail.js
+++ b/assets/js/club-detail.js
@@ -5,6 +5,7 @@ window.onload = function () {
     loadHeader();
     getClubDetail(clubId);
     hasClub();
+    isClubMaster();
     isMyClub();
     loadFooter();
 };
@@ -104,6 +105,29 @@ export default function getClubDetail(clubId) {
         });
 }
 
+function isClubMaster() {
+    const token = localStorage.getItem("accessToken");
+
+    axios
+        .get(`/api/club/clubMaster`, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        })
+        .then(function (response) {
+            console.log("dsfdf", response);
+            console.log(response.data.statusCode);
+            if (response.data.statusCode === 200) {
+                const applyingClubMatch =
+                    document.querySelector(".applyingClubMatch");
+                applyingClubMatch.style.display = "block";
+            }
+        })
+        .catch(function (error) {
+            console.log(error);
+        });
+}
+
 function isMyClub() {
     const urlParams = new URLSearchParams(window.location.search);
 
@@ -124,7 +148,9 @@ function isMyClub() {
                 updateBtn.style.display = "block";
                 const deleteBtn = document.querySelector(".deleteBtn");
                 deleteBtn.style.display = "block";
-            } else {
+                const applyingClubMatch =
+                    document.querySelector(".applyingClubMatch");
+                applyingClubMatch.style.display = "none";
             }
         })
         .catch(function (error) {

--- a/assets/js/dropmenu.js
+++ b/assets/js/dropmenu.js
@@ -136,7 +136,25 @@ async function toMyClub() {
     if (!token) {
         alert("로그인 후 이용 가능합니다.");
     }
-    window.location.href = "myClub.html";
+    console.log("here");
+    axios
+        .get("/api/club/myClub", {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        })
+        .then(function (response) {
+            console.log("제발", response);
+            if (response.data.data === true) {
+                alert("가입된 동아리가 없습니다.");
+            } else {
+                window.location.href = "myClub.html";
+            }
+        })
+        .catch(function (error) {
+            console.log(error);
+            console.log("백에서 return 잘 됐는데 왜 여기로 들어옴?ㄴ");
+        });
 }
 
 //로그아웃 하기

--- a/assets/js/myClub.js
+++ b/assets/js/myClub.js
@@ -135,6 +135,12 @@ function getMyClubId() {
                         updateBtn.style.display = "block";
                         const deleteBtn = document.querySelector(".deleteBtn");
                         deleteBtn.style.display = "block";
+                        const myClubApplication =
+                            document.querySelector(".myClubApplication");
+                        myClubApplication.style.display = "block";
+                        const matchManagement =
+                            document.querySelector(".matchManagement");
+                        matchManagement.style.display = "block";
                     } else {
                     }
                 })

--- a/assets/myClub.html
+++ b/assets/myClub.html
@@ -40,6 +40,7 @@
                 <button class="deleteBtn" onclick="deleteCheck()">
                     내 동아리 삭제
                 </button>
+                <button>대결 관리</button>
 
                 <div class="name">이름</div>
                 <div class="region">지역</div>

--- a/assets/myClub.html
+++ b/assets/myClub.html
@@ -40,7 +40,7 @@
                 <button class="deleteBtn" onclick="deleteCheck()">
                     내 동아리 삭제
                 </button>
-                <button>대결 관리</button>
+                <button class="matchManagement">대결 관리</button>
 
                 <div class="name">이름</div>
                 <div class="region">지역</div>

--- a/src/club/club.controller.ts
+++ b/src/club/club.controller.ts
@@ -69,6 +69,30 @@ export class ClubController {
         return clubId;
     }
 
+    // 동호회 장인지 체크
+    @ApiBearerAuth("accessToken")
+    @UseGuards(accessTokenGuard)
+    @Get("/clubMaster")
+    async isClubMaster(@UserId() userId: number) {
+        try{
+            const result = await this.clubService.isClubMaster(userId);
+
+            return {
+                statusCode:200,
+                message:"동호회장 조회에 성공했습니다.",
+                data: result
+            }
+        } catch(error) {
+            console.log(error);
+            
+            return {
+                statusCode:400,
+                message:"동호회장 조회에 실패했습니다.",
+                error: error.message
+            }
+        }
+    }
+
     //동아리 상세 조회
     @ApiBearerAuth("accessToken")
     @UseGuards(accessTokenGuard)

--- a/src/club/club.controller.ts
+++ b/src/club/club.controller.ts
@@ -41,7 +41,7 @@ export class ClubController {
         try {
             console.log("1######");
             const result = await this.clubService.hasClub(userId);
-
+            console.log("true 떠야함", result);
             return {
                 statusCode: 200,
                 message: "조회에 성공했습니다.",
@@ -53,7 +53,6 @@ export class ClubController {
 
             return {
                 statusCode: 400,
-                message: "조회에 실패했습니다.",
                 error: error.message,
             };
         }
@@ -74,22 +73,22 @@ export class ClubController {
     @UseGuards(accessTokenGuard)
     @Get("/clubMaster")
     async isClubMaster(@UserId() userId: number) {
-        try{
+        try {
             const result = await this.clubService.isClubMaster(userId);
 
             return {
-                statusCode:200,
-                message:"동호회장 조회에 성공했습니다.",
-                data: result
-            }
-        } catch(error) {
+                statusCode: 200,
+                message: "동호회장 조회에 성공했습니다.",
+                data: result,
+            };
+        } catch (error) {
             console.log(error);
-            
+
             return {
-                statusCode:400,
-                message:"동호회장 조회에 실패했습니다.",
-                error: error.message
-            }
+                statusCode: 400,
+                message: "동호회장 조회에 실패했습니다.",
+                error: error.message,
+            };
         }
     }
 

--- a/src/club/club.service.ts
+++ b/src/club/club.service.ts
@@ -244,4 +244,17 @@ export class ClubService {
 
         return user.clubId;
     }
+
+    async isClubMaster(userId) {
+        const clubMaster = await this.clubRepository.findOne({
+            where: { masterId: userId },
+        });
+
+        console.log("클럽 마스터", clubMaster);
+        if (!clubMaster) {
+            throw new NotFoundException("동아리 장이 아닙니다.");
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
<수정 사항>
- 내 동아리 페이지 대결관리 추가
- 동아리 상세 페이지
    - 동아리 장일 경우에만 대결 신청 띄우기
    - 내 동아리일 경우는 대결 신청 지우기
 - 동아리가 없을 경우 내 동아리 페이지로 이동 막기

요약 :
동아리 전체 조회 페이지 
- (동아리 없을 경우) 동아리 생성 버튼 보임

동아리 상세 페이지
- (동아리가 있으면서 동아리 장인 경우) 동아리 정보 수정/삭제 버튼 보임
- (동아리가 있으면서 동아리 장이면서 내 동아리가 아닌 경우) 대결 신청하기 버튼 보임
- (동아리가 없는 경우) 동아리 신청하기 버튼 보임

내 동아리 페이지 
- (동아리가 없을 경우) 내 동아리 페이지 이동 막음
- (동아리에 가입되어 있지만 동아리 장이 아닐경우) 버튼 안보임
- (동아리 장일 경우) 내 동아리 신청서 조회/대결관리/수정/삭제 버튼 보임
